### PR TITLE
Corrected emoji flag for Tigrinya (ti)

### DIFF
--- a/lib/emoji_flag/defaults.rb
+++ b/lib/emoji_flag/defaults.rb
@@ -146,7 +146,7 @@ module EmojiFlag
     te: 'IN',
     teo: 'UG',
     th: 'TH',
-    ti: 'ET',
+    ti: 'ER',
     to: 'TO',
     tr: 'TR',
     twq: 'NE',


### PR DESCRIPTION
I noticed that the flag for the Tigrinya language (`ti`) is currently the Ethiopian flag (🇪🇹/`et`), but it should be the Eritrea flag (🇪🇷/`er`).

Tigrinya is the official and primary working language of Eritrea ([https://en.wikipedia.org/wiki/Eritrea](https://en.wikipedia.org/wiki/Eritrea)), while it's only a minority language in Ethiopia – spoken by 5.9% ([https://en.wikipedia.org/wiki/Languages_of_Ethiopia](https://en.wikipedia.org/wiki/Languages_of_Ethiopia)).