### PR TITLE
Add caching and error handling to EmojiFlag.new method

### DIFF
--- a/lib/emoji_flag.rb
+++ b/lib/emoji_flag.rb
@@ -5,14 +5,25 @@ require 'emoji_flag/defaults'
 module EmojiFlag
   OFFSET = 127_397
   COUNTRY_CODE_RE = /^[A-Z]{2}$/
+  @cache = {}
 
   def self.new(input)
-    locale = input.to_s
-    return '' if locale.nil? || locale.size.zero?
+    locale = normalize_locale(input.to_s)
+    return @cache[locale] if @cache.key?(locale)
+
+    raise ArgumentError, "Locale cannot be nil or empty" if locale.nil? || locale.size.zero?
 
     code = code_for_locale(locale)
 
-    code.codepoints.collect { |codepoint| codepoint + OFFSET }.pack('U*')
+    raise ArgumentError, "No flag found for locale: #{locale}" if code.empty?
+
+    flag = code.codepoints.collect { |codepoint| codepoint + OFFSET }.pack('U*')
+    @cache[locale] = flag
+    flag
+  end
+
+  def self.normalize_locale(locale)
+    locale.strip.tr(' ', '_').tr('-', '_').downcase
   end
 
   def self.code_for_locale(locale)


### PR DESCRIPTION
This is a caching mechanism for better performance and error handling for the `EmojiFlag.new` method
I added the following:
- A `@cache` to store and get results for frequently asked results
- a `normalize_locale` method to standardize locale input formats
- Then some error handling for nill or empty locale inputs and unrecognized ones